### PR TITLE
Fallback locale for keyboard input on X11

### DIFF
--- a/examples/keyboard_state.rs
+++ b/examples/keyboard_state.rs
@@ -1,7 +1,7 @@
 use rdev::{EventType, Key, Keyboard, KeyboardState};
 
 fn main() {
-    let mut keyboard = Keyboard::new();
+    let mut keyboard = Keyboard::new().unwrap();
     let char_s = keyboard
         .add(&EventType::KeyPress(Key::KeyS))
         .unwrap()


### PR DESCRIPTION
In certain cases the system locale may not be supported for X11 (en_HK.UTF-8), in this case try some default ones, so at very least ANSI input would work for keyboards.

