### PR TITLE
UnicodeInfo: Serialize, Deserialize

### DIFF
--- a/src/codes_conv.rs
+++ b/src/codes_conv.rs
@@ -155,7 +155,7 @@ mod test {
                     continue;
                 }
                 if let Some(code2) = super::usb_hid_code_to_macos_code(usb_hid) {
-                    assert_eq!(code, code2 as u32)
+                    assert_eq!(code, code2 as crate::keycodes::macos_virtual_keycodes::CGKeyCode)
                 } else {
                     assert!(false, "We could not convert back code: {:?}", code);
                 }

--- a/src/rdev.rs
+++ b/src/rdev.rs
@@ -328,6 +328,7 @@ pub enum EventType {
 
 /// The Unicode information of input.
 #[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub struct UnicodeInfo {
     pub name: Option<String>,
     pub unicode: Vec<u16>,


### PR DESCRIPTION
Fixes the `serialize` feature by deriving `Serialize` and `Deserialize` for the `UnicodeInfo` type used within `Event`.